### PR TITLE
Fix Daylight Savings Bug

### DIFF
--- a/src/assets/ShareModal.svelte
+++ b/src/assets/ShareModal.svelte
@@ -87,6 +87,10 @@
                             eTime.getHours(),
                             eTime.getMinutes()
                         ],
+                        // specify local to ensure "floating" time (not fixed utc time)
+                        // we want this so that we arent "compensating" for DST
+                        startInputType: 'local',
+                        startOutputType: 'local',
                         title: scheduledClass.rootClass ?
                             `${scheduledClass.code}: ${scheduledClass.rootClass.code} — ${scheduledClass.rootClass.name}` :
                             `${scheduledClass.code} — ${scheduledClass.name}`,


### PR DESCRIPTION
There’s a bug where after DST spring forward courses will get pushed down an hour. This is caused because startOutputType is not set (it is UTC by default, we want it to be local).
![image](https://github.com/cabalex/slugschedule/assets/10778861/08cd5584-4f0b-4580-8e03-c83d228e4e4b)

Red is before the fix, blue is after.
![image](https://github.com/cabalex/slugschedule/assets/10778861/0181c2b5-7b9d-41f4-a129-1c72e82efc53)
Spring Forward happens on Sunday.
![image](https://github.com/cabalex/slugschedule/assets/10778861/da45706f-a8eb-495f-974b-f54d43843dcb)
